### PR TITLE
Store the changelog embed as json

### DIFF
--- a/src/main/java/ml/duncte123/skybot/commands/guild/owner/CustomCommandCommand.java
+++ b/src/main/java/ml/duncte123/skybot/commands/guild/owner/CustomCommandCommand.java
@@ -79,7 +79,7 @@ public class CustomCommandCommand extends Command {
             GuildSettings s = ctx.getGuildSettings();
             StringBuilder sb = new StringBuilder();
             manager.getCustomCommands().stream()
-                    .filter(c -> c.getGuildId().equals(event.getGuild().getId()))
+                    .filter(c -> c.getGuildId() == event.getGuild().getIdLong())
                     .forEach(cmd -> sb.append(s.getCustomPrefix())
                             .append(cmd.getName())
                             .append("\n")
@@ -89,7 +89,7 @@ public class CustomCommandCommand extends Command {
                     .appendCodeBlock(sb.toString(), "ldif").build());
         } else {
             //fetch a custom command
-            CustomCommand cmd = manager.getCustomCommand(arg, event.getGuild().getId());
+            CustomCommand cmd = manager.getCustomCommand(arg, event.getGuild().getIdLong());
             if (cmd != null)
                 //Run the custom command?
                 manager.dispatchCommand(cmd, arg, List.of(), event);
@@ -102,7 +102,7 @@ public class CustomCommandCommand extends Command {
         //Check for deleting
         if (args.get(0).equalsIgnoreCase("raw")) {
             final String commandName = args.get(1);
-            final String guildid = event.getGuild().getId();
+            final long guildid = event.getGuild().getIdLong();
 
             if (!commandExists(commandName, guildid, manager)) {
                 sendMsg(event, "No command was found for this name");
@@ -118,7 +118,7 @@ public class CustomCommandCommand extends Command {
             }
 
             final String commandName = args.get(1);
-            final String guildid = event.getGuild().getId();
+            final long guildid = event.getGuild().getIdLong();
 
             if (!commandExists(commandName, guildid, manager)) {
                 sendMsg(event, "No command was found for this name");
@@ -143,7 +143,7 @@ public class CustomCommandCommand extends Command {
 
 
             //fetch a custom command
-            CustomCommand cmd = manager.getCustomCommand(args.get(0), event.getGuild().getId());
+            CustomCommand cmd = manager.getCustomCommand(args.get(0), event.getGuild().getIdLong());
             if (cmd != null)
                 //Run the custom command?
                 manager.dispatchCommand(cmd, args.get(0), args.subList(1, args.size()), event);
@@ -170,7 +170,7 @@ public class CustomCommandCommand extends Command {
         }
 
         String commandAction = StringUtils.join(args.subList(2, args.size()), " ");
-        String guildId = event.getGuild().getId();
+        long guildId = event.getGuild().getIdLong();
         if (commandExists(commandName, guildId, manager)) {
 
             if (!args.get(0).equalsIgnoreCase("edit") && !args.get(0).equalsIgnoreCase("change")) {
@@ -205,11 +205,11 @@ public class CustomCommandCommand extends Command {
 
     }
 
-    private boolean commandExists(String name, String guild, CommandManager manager) {
+    private boolean commandExists(String name, long guild, CommandManager manager) {
         return manager.getCustomCommand(name, guild) != null;
     }
 
-    private Triple<Boolean, Boolean, Boolean> registerCustomCommand(String name, String action, String guildId, CommandManager manager) {
+    private Triple<Boolean, Boolean, Boolean> registerCustomCommand(String name, String action, long guildId, CommandManager manager) {
         return manager.addCustomCommand(new CustomCommandImpl(name, action, guildId));
     }
 

--- a/src/main/java/ml/duncte123/skybot/commands/uncategorized/ChangeLogCommand.java
+++ b/src/main/java/ml/duncte123/skybot/commands/uncategorized/ChangeLogCommand.java
@@ -25,23 +25,31 @@ import ml.duncte123.skybot.objects.command.CommandContext;
 import ml.duncte123.skybot.utils.EmbedUtils;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.entities.MessageEmbed;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
 
 import static ml.duncte123.skybot.utils.MessageUtils.sendEmbed;
 
 @Author(nickname = "duncte123", author = "Duncan Sterken")
 public class ChangeLogCommand extends Command {
 
-    private MessageEmbed embed = null;
+    private String embedJson = null;
 
     @Override
     public void executeCommand(@NotNull CommandContext ctx) {
-        if (embed != null) {
-            sendEmbed(ctx.getEvent(), embed);
-        } else {
+
+        if (embedJson == null || embedJson.isEmpty()) {
             fetchLatetstGitHubCommits(ctx.getEvent());
+            return;
         }
+
+        JDAImpl jda = (JDAImpl) ctx.getJDA();
+
+        MessageEmbed embed = jda.getEntityBuilder().createMessageEmbed(new JSONObject(embedJson));
+
+        sendEmbed(ctx.getEvent(), embed);
     }
 
     @Override
@@ -60,7 +68,10 @@ public class ChangeLogCommand extends Command {
             EmbedBuilder eb = EmbedUtils.defaultEmbed()
                     .setTitle("Changelog for DuncteBot", json.getString("html_url"))
                     .setDescription(body);
-            embed = eb.build();
+            MessageEmbed embed = eb.build();
+            embedJson = embed.toJSONObject()
+                    .put("type", "rich")
+                    .toString();
             sendEmbed(event, embed);
         });
     }


### PR DESCRIPTION
Fixes #60 

- [x] I have tested my changes.
- [ ] I didn't test my changes. I will do that in the following 7 days and agree that this Pull request will be closed if I don't test it in the named time span.
- [x] I know the language good enough for providing high-quality code.

Changes proposed in this pull request:
---

- Store the embed in a json string instead of the class

- Fix the custom command command to use longs

