### PR TITLE
Added a Speech AudioSourceManager

### DIFF
--- a/src/main/java/ml/duncte123/skybot/objects/audiomanagers/speech/SpeechAudioSourceManager.java
+++ b/src/main/java/ml/duncte123/skybot/objects/audiomanagers/speech/SpeechAudioSourceManager.java
@@ -105,7 +105,9 @@ public class SpeechAudioSourceManager implements AudioSourceManager {
     }
 
     @Override
-    public void encodeTrack(AudioTrack track, DataOutput output) {}
+    public void encodeTrack(AudioTrack track, DataOutput output) {
+        // empty because we don't need them
+    }
 
     @Override
     public AudioTrack decodeTrack(AudioTrackInfo trackInfo, DataInput input) {
@@ -113,7 +115,9 @@ public class SpeechAudioSourceManager implements AudioSourceManager {
     }
 
     @Override
-    public void shutdown() {}
+    public void shutdown() {
+        // empty because we don't need them
+    }
 
     HttpInterface getHttpInterface() {
         return httpInterfaceManager.getInterface();

--- a/src/main/java/ml/duncte123/skybot/objects/audiomanagers/speech/SpeechAudioSourceManager.java
+++ b/src/main/java/ml/duncte123/skybot/objects/audiomanagers/speech/SpeechAudioSourceManager.java
@@ -1,0 +1,121 @@
+/*
+ * Skybot, a multipurpose discord bot
+ *      Copyright (C) 2017 - 2018  Duncan "duncte123" Sterken & Ramid "ramidzkh" Khan
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ml.duncte123.skybot.objects.audiomanagers.speech;
+
+import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
+import com.sedmelluq.discord.lavaplayer.track.AudioItem;
+import com.sedmelluq.discord.lavaplayer.track.AudioReference;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import ml.duncte123.skybot.Author;
+
+@Author(nickname = "ramidzkh", author = "Ramid Khan")
+public class SpeechAudioSourceManager implements AudioSourceManager {
+
+    private static final String PREFIX = "speak:";
+    private static final String GOOGLE_TRANSLATE_URL = "https://translate.google.com/translate_Speech" +
+            "?tl=%language%" +
+            "&q=%query%" +
+            "&ie=UTF-8&total=1&idx=0" +
+            "&text" + "len=%length%" +
+            "&client=tw-ob";
+
+    private final int limit;
+    private final String templateURL;
+    private final HttpInterfaceManager httpInterfaceManager;
+
+    /**
+     * @param limit The character limit of the text, not including prepended or trailing whitespaces
+     * @param language The language and accent code to play back audio in
+     */
+    public SpeechAudioSourceManager(int limit, String language) {
+        this.limit = limit;
+        this.templateURL = GOOGLE_TRANSLATE_URL.replace("%language%", language);
+        httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager();
+    }
+
+    @Override
+    public String getSourceName() {
+        return "speak";
+    }
+
+    @Override
+    public AudioItem loadItem(DefaultAudioPlayerManager manager, AudioReference reference) {
+        // We check if it's larger so we don't send requests of nothing
+        if(reference.identifier.startsWith(PREFIX)
+                && reference.identifier.length() > PREFIX.length()) {
+            String data = reference.identifier.substring(PREFIX.length());
+            data = data
+                    // Remove whitespaces at the end
+                    .trim()
+                    // Remove whitespaces at the front
+                    .replaceAll("^\\s+", "")
+                    // Limit the length
+                    .substring(0, Math.min(data.length(), limit));
+
+            String encoded;
+
+            try {
+                encoded = URLEncoder.encode(data, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new FriendlyException("Could not encode data", FriendlyException.Severity.FAULT, e);
+            }
+
+            String mp3URL = templateURL
+                    .replace("%length%", Integer.toString(data.length()))
+                    .replace("%query%", encoded);
+
+            // Redirect to somewhere else
+            return new AudioReference(mp3URL, "Speaking " + data);
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean isTrackEncodable(AudioTrack track) {
+        return true;
+    }
+
+    @Override
+    public void encodeTrack(AudioTrack track, DataOutput output) {}
+
+    @Override
+    public AudioTrack decodeTrack(AudioTrackInfo trackInfo, DataInput input) {
+        return new SpeechAudioTrack(trackInfo, this);
+    }
+
+    @Override
+    public void shutdown() {}
+
+    HttpInterface getHttpInterface() {
+        return httpInterfaceManager.getInterface();
+    }
+}

--- a/src/main/java/ml/duncte123/skybot/objects/audiomanagers/speech/SpeechAudioTrack.java
+++ b/src/main/java/ml/duncte123/skybot/objects/audiomanagers/speech/SpeechAudioTrack.java
@@ -1,0 +1,72 @@
+/*
+ * Skybot, a multipurpose discord bot
+ *      Copyright (C) 2017 - 2018  Duncan "duncte123" Sterken & Ramid "ramidzkh" Khan
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ml.duncte123.skybot.objects.audiomanagers.speech;
+
+import com.sedmelluq.discord.lavaplayer.container.mp3.Mp3AudioTrack;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+import com.sedmelluq.discord.lavaplayer.track.DelegatedAudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
+import ml.duncte123.skybot.Author;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+@Author(nickname = "ramidzkh", author = "Ramid Khan")
+public class SpeechAudioTrack extends DelegatedAudioTrack {
+
+    private static final Logger log = LoggerFactory.getLogger(SpeechAudioTrack.class);
+
+    private final SpeechAudioSourceManager manager;
+
+    SpeechAudioTrack(AudioTrackInfo trackInfo, SpeechAudioSourceManager manager) {
+        super(trackInfo);
+        this.manager = manager;
+    }
+
+    @Override
+    public void process(LocalAudioTrackExecutor executor) throws Exception {
+        try (HttpInterface httpInterface = manager.getHttpInterface()) {
+            loadStream(executor, httpInterface);
+        }
+    }
+
+    private void loadStream(LocalAudioTrackExecutor localExecutor, HttpInterface httpInterface) throws Exception {
+        String trackUrl = trackInfo.identifier;
+        log.debug("Starting Speech speech from URL: {}", trackUrl);
+
+        try (PersistentHttpStream stream = new PersistentHttpStream(httpInterface, new URI(trackUrl), null)) {
+            processDelegate(new Mp3AudioTrack(trackInfo, stream), localExecutor);
+        }
+    }
+
+    @Override
+    public AudioTrack makeClone() {
+        return new SpeechAudioTrack(trackInfo, manager);
+    }
+
+    @Override
+    public AudioSourceManager getSourceManager() {
+        return manager;
+    }
+}

--- a/src/main/java/ml/duncte123/skybot/utils/AudioUtils.java
+++ b/src/main/java/ml/duncte123/skybot/utils/AudioUtils.java
@@ -40,6 +40,7 @@ import ml.duncte123.skybot.commands.music.RadioCommand;
 import ml.duncte123.skybot.objects.RadioStream;
 import ml.duncte123.skybot.objects.TrackUserData;
 import ml.duncte123.skybot.objects.audiomanagers.clypit.ClypitAudioSourceManager;
+import ml.duncte123.skybot.objects.audiomanagers.speech.SpeechAudioSourceManager;
 import ml.duncte123.skybot.objects.audiomanagers.spotify.SpotifyAudioSourceManager;
 import ml.duncte123.skybot.objects.command.CommandContext;
 import ml.duncte123.skybot.objects.config.DunctebotConfig;
@@ -109,25 +110,22 @@ public class AudioUtils {
     private void initPlayerManager() {
         if (playerManager == null) {
             playerManager = new DefaultAudioPlayerManager();
-//            playerManager.enableGcMonitoring();
+            //playerManager.enableGcMonitoring();
 
-            //Disable cookies for youtube
+            // Disable cookies for youtube
             YoutubeAudioSourceManager youtubeAudioSourceManager = new YoutubeAudioSourceManager(true);
-
-            SoundCloudAudioSourceManager soundcloud = new SoundCloudAudioSourceManager();
 
             playerManager.registerSourceManager(new SpotifyAudioSourceManager(youtubeAudioSourceManager, config));
             playerManager.registerSourceManager(new ClypitAudioSourceManager());
-
+            playerManager.registerSourceManager(new SpeechAudioSourceManager(100, "en-AU"));
 
             playerManager.registerSourceManager(youtubeAudioSourceManager);
-            playerManager.registerSourceManager(soundcloud);
+            playerManager.registerSourceManager(new SoundCloudAudioSourceManager());
             playerManager.registerSourceManager(new BandcampAudioSourceManager());
             playerManager.registerSourceManager(new VimeoAudioSourceManager());
             playerManager.registerSourceManager(new TwitchStreamAudioSourceManager());
             playerManager.registerSourceManager(new BeamAudioSourceManager());
             playerManager.registerSourceManager(new HttpAudioSourceManager());
-
 
             AudioSourceManagers.registerLocalSource(playerManager);
         }


### PR DESCRIPTION
Lets someone to use Google Translate's API to generate speech from some input text.
---
- [x] I have tested my changes. (Locally, not running not a bot instance) 
- [x] I know the language good enough for providing high-quality code.
---
## Changes proposed in this pull request:
* This proposal adds a LavaPlayer AudioSourceManager, which allows to play speech to someone. The usage of the source manager is `speech: <text to play>`, and plays it in a set language (set to be English/Australia as of right now). I'm making this feature to not be Patreon locked because
  * It's simply a link that follows to an MP3 stream
  * It's harder to implement
## Things that might need changing
* The current language and accent is hard coded to be `en-AU` or English/Australia
---
This feature was influenced by the simplicity of using Google's API to generate speech shown [here](https://github.com/lkuza2/java-speech-api/blob/master/src/main/java/com/darkprograms/speech/synthesiser/Synthesiser.java)
